### PR TITLE
Clean up the types, so that prompts are typed specifically based on t…

### DIFF
--- a/dev/browser/types/index.ts
+++ b/dev/browser/types/index.ts
@@ -1,0 +1,14 @@
+import { Contortionist } from "../../../packages/contortionist/src/contortionist.js";
+
+const contortionllamafileNonStreaming = new Contortionist({ grammar: 'g', model: { endpoint: 'a', protocol: 'llamafile', }, });
+contortionllamafileNonStreaming.execute('p', {
+  stream: false,
+  callback: ({ chunk, }) => console.log(chunk),
+});
+const contortionllamafileStreaming = new Contortionist({ grammar: 'g', model: { endpoint: 'a', protocol: 'llamafile', }, });
+contortionllamafileStreaming.execute('p', {
+  stream: true,
+  callback: ({ chunk, }) => console.log(chunk),
+});
+const contortionllamacpp = new Contortionist({ grammar: 'g', model: { endpoint: 'b', protocol: 'llama.cpp', }, });
+contortionllamacpp.execute('p', { callback: ({ chunk, }) => console.log(chunk), });

--- a/packages/contortionist/src/contortionist.ts
+++ b/packages/contortionist/src/contortionist.ts
@@ -1,9 +1,19 @@
 import { getLLM, } from "./llms/index.js";
-import { ChosenLLM, ConstructorOptions, DEFAULT_N, ExternalExecuteOptions, Grammar, ModelDefinition, ModelProtocol, Prompt, } from "./types.js";
+import {
+  DEFAULT_N,
+  type ConstructorOptions,
+  type ExternalExecuteOptions,
+  type Grammar,
+  type ILLM,
+  type ModelDefinition,
+  type ModelProtocol,
+  type Prompt,
+} from "./types.js";
 
 export class Contortionist<M extends ModelProtocol> {
   private _grammar?: Grammar;
-  private _llm?: ChosenLLM<M>;
+  // private _llm?: ChosenLLM<M>;
+  private _llm?: ILLM;
 
   /**
    * @hidden
@@ -38,35 +48,52 @@ export class Contortionist<M extends ModelProtocol> {
   public set llm(model: ModelDefinition<M> | undefined) {
     this._llm = model ? getLLM<M>(model) : undefined;
   }
-  public get llm(): ChosenLLM<M> {
+  public get llm(): ILLM {
     if (!this._llm) {
       throw new Error('You must set an LLM before running.');
     }
     return this._llm;
   }
 
-  async execute<S extends boolean>(prompt: Prompt<M>, {
+  /**
+   * Executes a prompt against an LLM backend.
+   * 
+   * ```javascript
+   * const contortionist = new Contortionist({
+   *  model: { protocol: 'llama.cpp', endpoint: '/path/to/api' },
+   *  grammar: ' ... some grammar ... ',
+   * });
+   * contortionist.execute('Write me some code', {
+   *  n: 128,
+   *  stream: true,
+   *  callback: ({ partial, chunk, }) => {
+   *    console.log(partial); // the partially built string for each streaming response
+   *    console.log(chunk); // the full parsed JSON chunk returned for the streaming response
+   *  },
+   * })
+   * contortionist.abort();
+   * ```
+   */
+  execute<S extends boolean>(prompt: Prompt<M>, {
     n = DEFAULT_N,
     stream,
     callback,
     signal,
-  }: ExternalExecuteOptions<M, S> = {}) {
+  }: ExternalExecuteOptions<M, S>) {
     if (!this._llm) {
       throw new Error('You must set an LLM before running.');
     }
     if (stream === false && callback) {
       console.warn('streamCallback is ignored when stream is false');
     }
-    const llm: ChosenLLM<M> = this.llm;
-    const r = await llm.execute({
+    return this.llm.execute({
+      prompt,
       n,
       stream: (callback && stream === undefined) ? true : !!stream,
       callback,
-      prompt,
       grammar: this._grammar,
       signal: signal || this._abortController.signal,
     });
-    return r;
   };
 
   /**
@@ -82,19 +109,3 @@ export class Contortionist<M extends ModelProtocol> {
     this._abortController = new AbortController();
   };
 }
-
-const c1 = new Contortionist({
-  model: {
-    endpoint: 'foo',
-    protocol: 'llama.cpp',
-  },
-});
-c1.llm;
-
-const c2 = new Contortionist({
-  model: {
-    endpoint: 'foo',
-    protocol: 'llamafile',
-  },
-});
-c2.llm;

--- a/packages/contortionist/src/llms/endpoint-llms/llama-cpp/llama-cpp-llm.ts
+++ b/packages/contortionist/src/llms/endpoint-llms/llama-cpp/llama-cpp-llm.ts
@@ -4,15 +4,21 @@ import { parseChunk, } from './parse-chunk.js';
 import { isError, } from "./is-error.js";
 import { parse, } from "./parse.js";
 import { buildResponse, } from "./build-response.js";
-
-
-export class LlamaCPPLLM {
+import { ILLM, } from "../../../types.js";
+export class LlamaCPPLLM implements ILLM {
   endpoint: string;
   constructor(endpoint: string) {
     this.endpoint = endpoint;
   };
 
-  execute = async ({ prompt, callback: _callback, signal, n, grammar, stream, }: LlamaCPPExecuteOptions) => {
+  async execute<S extends boolean>({
+    prompt,
+    n,
+    stream,
+    callback: _callback,
+    grammar,
+    signal,
+  }: LlamaCPPExecuteOptions<S>) {
     let partial = '';
     const callback = (chunk: string) => {
       if (_callback) {

--- a/packages/contortionist/src/llms/endpoint-llms/llama-cpp/types.ts
+++ b/packages/contortionist/src/llms/endpoint-llms/llama-cpp/types.ts
@@ -1,6 +1,10 @@
-import { InternalExecuteOptions as _InternalExecuteOptions, } from "../../../types.js";
+import { Callback, InternalExecuteOptions, } from "../../../types.js";
+export interface LlamaCPPExecuteOptions<S extends boolean> extends InternalExecuteOptions {
+  prompt: LlamaCPPPrompt;
+  callback: Callback<'llama.cpp', S>;
+}
 
-export type LlamaCPPExecuteOptions = _InternalExecuteOptions<'llama.cpp'>;
+export type LlamaCPPPrompt = string;
 
 export interface LlamaCPPCallOpts {
   prompt: string;

--- a/packages/contortionist/src/llms/endpoint-llms/llamafile/llamafile-llm.ts
+++ b/packages/contortionist/src/llms/endpoint-llms/llamafile/llamafile-llm.ts
@@ -2,22 +2,30 @@ import { fetchAPI, } from "../fetch-api/fetch-api.js";
 import { buildResponse, } from "./build-response.js";
 import { parse, } from "./parse.js";
 import { parseChunk, } from "./parse-chunk.js";
-import { LlamafileExecuteOptions, } from "./types.js";
+import { LlamafileExecuteOptions, NonStreamingLlamafileResponse, StreamingLlamafileResponse, } from "./types.js";
 import { getContent, } from "./get-content.js";
 import { isError, } from "./is-error.js";
 import { getMessages, } from "./get-messages.js";
+import { ILLM, } from "../../../types.js";
 
-export class LlamafileLLM {
+export class LlamafileLLM implements ILLM {
   endpoint: string;
   constructor(endpoint: string) {
     this.endpoint = endpoint;
   };
 
-  execute = async ({ prompt, callback: _callback, signal, n, grammar, stream, }: LlamafileExecuteOptions) => {
+  async execute<S extends boolean>({
+    prompt,
+    n,
+    grammar,
+    stream,
+    callback: _callback,
+    signal,
+  }: LlamafileExecuteOptions<S>) {
     let partial = '';
     const callback = (chunk: string) => {
       if (_callback) {
-        const parsedChunk = parse(chunk);
+        const parsedChunk = parse<S extends true ? StreamingLlamafileResponse : NonStreamingLlamafileResponse>(chunk);
         partial += getContent(parsedChunk);
         _callback({ partial, chunk: parsedChunk, });
       }

--- a/packages/contortionist/src/llms/endpoint-llms/llamafile/types.ts
+++ b/packages/contortionist/src/llms/endpoint-llms/llamafile/types.ts
@@ -1,7 +1,12 @@
-import { InternalExecuteOptions, } from "../../../types.js";
+import { Callback, InternalExecuteOptions, } from "../../../types.js";
 
 export type LlamafilePrompt = string | Message[];
-export type LlamafileExecuteOptions = InternalExecuteOptions<StreamingLlamafileResponse | NonStreamingLlamafileResponse, LlamafilePrompt>;
+
+export interface LlamafileExecuteOptions<S extends boolean> extends InternalExecuteOptions {
+  prompt: LlamafilePrompt;
+  callback: Callback<'llamafile', S>;
+
+}
 
 type Role = 'user' | 'assistant' | 'system';
 export interface Message {


### PR DESCRIPTION
…he model provided, and callbacks receive appropriately parsed chunks dependent on the model protocol