### PR TITLE
Remove n as a top-level option, and provide passthrough

### DIFF
--- a/packages/contort/src/contortionist.ts
+++ b/packages/contort/src/contortionist.ts
@@ -69,7 +69,6 @@ export class Contortionist<M extends ModelProtocol> {
    * ```
    */
   async execute<S extends boolean>(prompt: Prompt<M>, {
-    n = DEFAULT_N,
     stream,
     callback,
     signal: signal,
@@ -84,7 +83,6 @@ export class Contortionist<M extends ModelProtocol> {
     const llm = await _llm;
     return llm.execute({
       prompt,
-      n,
       stream: (callback && stream === undefined) ? true : !!stream,
       callback,
       grammar: this.grammar,

--- a/packages/contort/src/contortionist.ts
+++ b/packages/contort/src/contortionist.ts
@@ -1,6 +1,5 @@
 import { getLLM, } from "./llms/index.js";
 import {
-  DEFAULT_N,
   type ConstructorOptions,
   type ExternalExecuteOptions,
   type Grammar,

--- a/packages/contort/src/llms/endpoint-llms/llama-cpp/llama-cpp-llm.ts
+++ b/packages/contort/src/llms/endpoint-llms/llama-cpp/llama-cpp-llm.ts
@@ -13,11 +13,11 @@ export class LlamaCPPLLM implements ILLM {
 
   async execute<S extends boolean>({
     prompt,
-    n,
     stream,
     callback: _callback,
     grammar,
     signal,
+    ...rest
   }: LlamaCPPExecuteOptions<S>) {
     let partial = '';
     const callback = (chunk: string) => {
@@ -34,8 +34,8 @@ export class LlamaCPPLLM implements ILLM {
       callback,
       parseChunk,
     }, {
+      ...rest,
       prompt,
-      n_predict: n,
       grammar,
       stream,
     });

--- a/packages/contort/src/llms/endpoint-llms/llama-cpp/types.ts
+++ b/packages/contort/src/llms/endpoint-llms/llama-cpp/types.ts
@@ -8,7 +8,6 @@ export type LlamaCPPPrompt = string;
 
 export interface LlamaCPPCallOpts {
   prompt: string;
-  n_predict: number;
   grammar: string;
   stream: boolean;
 }

--- a/packages/contort/src/llms/endpoint-llms/llamafile/llamafile-llm.ts
+++ b/packages/contort/src/llms/endpoint-llms/llamafile/llamafile-llm.ts
@@ -16,11 +16,11 @@ export class LlamafileLLM implements ILLM {
 
   async execute<S extends boolean>({
     prompt,
-    n,
     grammar,
     stream,
     callback: _callback,
     signal,
+    ...rest
   }: LlamafileExecuteOptions<S>) {
     let partial = '';
     const callback = (chunk: string) => {
@@ -37,8 +37,8 @@ export class LlamafileLLM implements ILLM {
       callback,
       parseChunk,
     }, {
+      ...rest,
       messages: getMessages(prompt),
-      n,
       grammar: !grammar ? undefined : grammar,
       stream,
     });

--- a/packages/contort/src/llms/js-llms/transformersjs-llm/transformersjs-llm.test.ts
+++ b/packages/contort/src/llms/js-llms/transformersjs-llm/transformersjs-llm.test.ts
@@ -26,4 +26,5 @@ describe('TransformersJSLLM', () => {
     const llm = new TransformersJSLLM(mockPipeline);
     expect(llm.pipeline).toBe(mockPipeline);
   });
+  // max_new_tokens: n,
 });

--- a/packages/contort/src/llms/js-llms/transformersjs-llm/transformersjs-llm.ts
+++ b/packages/contort/src/llms/js-llms/transformersjs-llm/transformersjs-llm.ts
@@ -25,10 +25,10 @@ export class TransformersJSLLM {
 
   async execute({
     prompt,
-    n,
     grammar,
     callback,
     // signal,
+    ...rest
   }: TransformersJSExecuteOptions) {
     const tokenizer = this.pipeline.tokenizer as PreTrainedTokenizer;
     const callbackFunction = callback ? (beams: Beam[]) => {
@@ -43,8 +43,7 @@ export class TransformersJSLLM {
     } : undefined;
     const generate_kwargs = {
       temperature: DEFAULT_TEMPERATURE,
-      // ...opts,
-      max_new_tokens: n,
+      ...rest,
 
       callback_function: callbackFunction,
       // num_beams: 5,

--- a/packages/contort/src/llms/js-llms/transformersjs-llm/types.ts
+++ b/packages/contort/src/llms/js-llms/transformersjs-llm/types.ts
@@ -60,13 +60,6 @@ export interface TransformersJSExecuteOptions extends Omit<InternalExecuteOption
   callback: Callback;
 }
 
-// export interface TransformersJSCallOpts {
-//   prompt: string;
-//   n_predict: number;
-//   grammar: string;
-//   stream: boolean;
-// }
-
 export interface TransformersJSError {
   code: number;
   message: string;

--- a/packages/contort/src/types.ts
+++ b/packages/contort/src/types.ts
@@ -33,13 +33,11 @@ export interface InternalExecuteOptions {
   stream: boolean;
   signal: AbortSignal;
 }
-export interface ExternalExecuteOptions<M extends ModelProtocol, S extends boolean> {
-  n?: number;
+export interface ExternalExecuteOptions<M extends ModelProtocol, S extends boolean> extends Record<string, unknown> {
   stream?: S;
   callback?: Callback<M, S>;
   signal?: AbortSignal;
 }
-export const DEFAULT_N = 20;
 
 export interface ConstructorOptions<M extends ModelProtocol | undefined = undefined> {
   grammar?: Grammar;
@@ -68,7 +66,6 @@ export interface ILLM {
     prompt: Prompt<ModelProtocol>;
     stream: boolean;
     callback?: Callback<ModelProtocol, S>;
-    n: number;
     grammar?: string;
     signal: AbortSignal;
   }): Promise<string>;

--- a/test/llamacpp.test.ts
+++ b/test/llamacpp.test.ts
@@ -98,7 +98,7 @@ describe('llama.cpp', () => {
         }))}`);
       });
       const result = await contortionist.execute('prompt', {
-        n: 10,
+        n_predict: 10,
       });
       expect(result).toEqual(content);
     });
@@ -128,7 +128,7 @@ describe('llama.cpp', () => {
         resolveCatchPromise();
       });
       contortionist.execute('prompt', {
-        n: 10,
+        n_predict: 10,
         signal: abortController.signal,
       }).then(resultFn).catch(catchFn);
       await serverCalledPromise;
@@ -167,14 +167,14 @@ describe('llama.cpp', () => {
       });
       const requests = [
         contortionist.execute('prompt1', {
-          n: 10,
+          n_predict: 10,
         }),
         contortionist.execute('prompt2', {
-          n: 10,
+          n_predict: 10,
         }),
       ];
       contortionist.execute('aborted prompt', {
-        n: 10,
+        n_predict: 10,
         signal: abortController.signal,
       }).then(resultFn).catch(catchFn);
       await serverCalledPromise;

--- a/test/tests/protocols/llamacpp.test.ts
+++ b/test/tests/protocols/llamacpp.test.ts
@@ -104,7 +104,7 @@ describe('llama.cpp', async () => {
       });
       const callback = vi.fn();
       const result = await contortionist.execute('prompt', {
-        n,
+        n_predict: n,
         callback,
       });
       expect(result).toEqual(content);


### PR DESCRIPTION
Allow LLMs to accept the ...rest spread of remaining options